### PR TITLE
argument of length 0 error

### DIFF
--- a/R/board_rsconnect_bundle.R
+++ b/R/board_rsconnect_bundle.R
@@ -1,5 +1,5 @@
 
-add_user_html <- function(dir, path = getOption("RSCONNECT_HTML_PATH")) {
+add_user_html <- function(dir, path = getOption("RSCONNECT_HTML_PATH", "")) {
   if (path != "") {
     file.copy(path, file.path(dir, "index.html"), overwrite = TRUE)
   }


### PR DESCRIPTION
Adds a default `""` to `add_user_html()` so that the if block doesn't error when there is no option set.

Alternatively, the test in the if block could be `is.null`